### PR TITLE
Chiusura manuale terminata

### DIFF
--- a/app/aste.js
+++ b/app/aste.js
@@ -127,42 +127,62 @@ router.put('/:id', async function(req, res) {
     if(!asta) 
         return res.status(404).json({ success: false, message: 'Asta non trovata'});
 
-    if(asta.DettagliAsta.Venditore == req.headers["id-account"]){
-        return res.status(400).json({ success: false, message: "Non puoi offrire per un'asta creata da te stesso"});
-    }
-
-    let dateTimeAttuale = new Date().getTime();
-    if(asta.DettagliAsta.Inizio > dateTimeAttuale || asta.DettagliAsta.Fine < dateTimeAttuale){
-        return res.status(400).json({ success: false, message: 'Non puoi offrire per questa asta'});
-    }
-
-    if((asta.DettagliAsta.Tipo == 1 && asta.DettagliAsta.Offerte.length != 0 && req.body.prezzo <= asta.DettagliAsta.Offerte[0]) || (asta.DettagliAsta.PrezzoMinimo && req.body.prezzo < asta.DettagliAsta.PrezzoMinimo))
-        return res.status(400).json({ success: false, message: 'Prezzo troppo basso'});
-
-    if(isNaN(req.body.prezzo) || req.body.prezzo==null){
-        return res.status(400).json({ success: false, message: 'Prezzo non valido'});
-    }
-
-    if(asta.DettagliAsta.Tipo == 0 && asta.DettagliAsta.Offerenti.indexOf(req.headers["id-account"]) > -1){
-        return res.status(400).json({ success: false, message: "L'asta è a busta chiusa ed è presente già una tua offerta"});
-    }
-
-    let pos = 0;
-    if(asta.DettagliAsta.Tipo == 0){
-        while(asta.DettagliAsta.Offerte[pos] > req.body.prezzo && pos < asta.DettagliAsta.Offerte.length){
-            pos++;
+    if(req.query.put == 'fine') {
+        if(asta.DettagliAsta.Venditore == req.headers['id-account']) {
+            asta.DettagliAsta.Fine = new Date();
+            await asta.save();
+            code = 200;
+            success = true;
+            message = 'Asta conclusa correttamente';
+        } else {
+            code = 400;
+            success = false;
+            message = 'Quest\'asta non ti appartiene';
         }
+    } else {
+        if(asta.DettagliAsta.Venditore == req.headers["id-account"])
+            return res.status(400).json({ success: false, message: "Non puoi offrire per un'asta creata da te stesso"});
+
+        let dateTimeAttuale = new Date().getTime();
+
+        if(asta.DettagliAsta.Inizio > dateTimeAttuale || asta.DettagliAsta.Fine < dateTimeAttuale)
+            return res.status(400).json({ success: false, message: 'Non puoi offrire per questa asta'});
+
+        if((asta.DettagliAsta.Tipo == 1 && asta.DettagliAsta.Offerte.length != 0 && req.body.prezzo <= asta.DettagliAsta.Offerte[0]) || (asta.DettagliAsta.PrezzoMinimo && req.body.prezzo < asta.DettagliAsta.PrezzoMinimo))
+            return res.status(400).json({ success: false, message: 'Prezzo troppo basso'});
+
+        if(isNaN(req.body.prezzo) || req.body.prezzo==null)
+            return res.status(400).json({ success: false, message: 'Prezzo non valido'});
+
+        if(asta.DettagliAsta.Tipo == 0 && asta.DettagliAsta.Offerenti.indexOf(req.headers["id-account"]) > -1)
+            return res.status(400).json({ success: false, message: "L'asta è a busta chiusa ed è presente già una tua offerta"});
+
+        let pos = 0;
+
+        if(asta.DettagliAsta.Tipo == 0)
+            while(asta.DettagliAsta.Offerte[pos] > req.body.prezzo && pos < asta.DettagliAsta.Offerte.length)
+                pos++;
+
+        await Asta.updateOne({
+            _id: req.params.id
+        }, {
+            $push: {
+                'DettagliAsta.Offerte': {
+                    $each: [parseFloat(req.body.prezzo)], $position:pos
+                },
+                'DettagliAsta.Offerenti': {
+                    $each: [req.headers["id-account"]],$position:pos
+                }
+            }
+        });
+
+        return res.status(200).json({ message: 'Nuova offerta avvenuta con successo', success: true });
     }
 
-    await Asta.updateOne({
-        _id: req.params.id
-    },
-    {
-        $push:{'DettagliAsta.Offerte':{$each:[parseFloat(req.body.prezzo)],$position:pos},
-        'DettagliAsta.Offerenti':{$each:[req.headers["id-account"]],$position:pos}}
-    })
-
-    return res.status(200).json({ message: 'Nuova offerta avvenuta con successo', success: true });
+    return res.status(code).json({
+        success: success,
+        message: message
+    });
 });
 
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "start-local": "node -r dotenv/config index.js"
+    "start-local": "nodemon -r dotenv/config index.js"
   },
   "repository": {
     "type": "git",

--- a/static/dettaglioAsta.html
+++ b/static/dettaglioAsta.html
@@ -6,8 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
     <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.3.1/dist/css/bootstrap.min.css"
-        integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.3.0/font/bootstrap-icons.css" rel="stylesheet">
 
     <!-- Our CSS -->
@@ -132,7 +131,7 @@
         <div style="border-style: solid; border-color: #38d996; height:400px; height: 650px; border-radius: 50px;">
 
 
-            <div class="card-body">
+            <div class="card-body" id="cardBody">
                 <div style="text-align: center;">
                     <div id="nomeAsta" style="color: white; font-size: larger;display:inline;width:50%"><b>Nome
                             dell'asta</b></div>
@@ -200,9 +199,6 @@
                 </form>
                 <div id="offri" style="text-align: center;" hidden><input type="number" id="offerta" step="0.01"><button
                         id="inviaOfferta">Offri</button></div>
-
-
-
             </div>
         </div>
     </div>

--- a/static/scriptDettaglioAsta.js
+++ b/static/scriptDettaglioAsta.js
@@ -299,6 +299,33 @@ function caricaDettagliAsta() {
                 let now = new Date().getTime();
                 if(new Date(data.inizioAsta).getTime() < now){
                     caricaDettagliAstaAttiva(data, now);
+
+                    if(data.venditoreAsta._id == sessionStorage.getItem('id')) {
+                        btnChiusura = document.createElement('button');
+                        btnChiusura.className = 'btn btn-lg btn-warning float-end me-5 text-nowrap';
+                        btnChiusura.innerHTML = 'Chiudi asta';
+                        
+                        btnChiusura.onclick = function() {
+                            fetch('../api/v1/aste/' + idAsta + '?put=fine', {
+                                method: 'PUT',
+                                headers: { 
+                                    'Content-Type': 'application/json',
+                                    'id-account': sessionStorage.getItem('id')
+                                }
+                            })
+                            .then((resp) => resp.json())
+                            .then(function (data) {
+                                document.getElementById('modalContent').className = 'modal-content bg-' + (data.success ? 'success' : 'warning');
+                                document.getElementById('modalTitle').innerHTML = (data.success ? 'Successo' : 'Errore');
+                                document.getElementById('message').innerHTML = data.message;
+                                $('#alert').modal('show');
+                            })
+                            .catch(error => console.error(error)); // If there is any error you will catch them here
+                        }
+
+                        btnChiusura.type = 'button';
+                        document.getElementById('cardBody').appendChild(btnChiusura);
+                    }
                 }
                 else{
                     caricaDettagliAstaInAttesa(data, now);


### PR DESCRIPTION
Aggiunto un bottone nella pagina di dettaglio asta che compare solo se si è i creatori dell'asta visualizzata. Quando si preme il pulsante, l'asta viene chiusa grazie ad una chiamata PUT ad un'API che modifica la data e l'orario di chiusura dell'asta impostandoli alla data e all'orario attuali